### PR TITLE
Add section to team member pages to auto-populate publications

### DIFF
--- a/_data/publication_list.yml
+++ b/_data/publication_list.yml
@@ -1,0 +1,32 @@
+- title: "Classification of Epithelial Ovarian Carcinoma Whole-Slide Pathology Images Using Deep Transfer Learning"
+  authors: Yiping Wang, David Farnell, Hossein Farahani, Mitchell Nursey, Basile Tessier-Cloutier, Steven JM Jones, David G Huntsman, C Blake Gilks, Ali Bashashati
+  year: 2020
+  preprint: 0
+  url: https://arxiv.org/abs/2005.10957
+  display: "arXiv preprint arXiv:2005.10957"
+
+- title: "Synthesis of high resolution glioma pathology images using generative adversarial networks"
+  authors: Adrian Levine, Jason Peng, David Farnell, Mitchell Nursey, Yiping Wang, Steven Jones, C Blake Gilks, Ali Bashashati, Stephen Yip
+  year: 2020
+  preprint: 0
+  url: 
+  display: 
+
+- title: "Synthesis of diagnostic quality cancer pathology images by generative adversarial networks"
+  authors: Adrian B. Levine, Jason Peng, David Farnell, Mitchell Nursey, Yiping Wang, Julia R. Naso, Hezhen Ren, Hossein Farahani, Colin Chen, Derek Chiu, Aline Talhouk, Brandon Sheffield, Maziar Riazy, Philip P. Ip, Carlos Parra-Herran, Anne Mills, Naveena Singh, Basile Tessier-Cloutier, Taylor Salisbury, Jonathan Lee, Tim Salcudean, Steven J.M. Jones, David G. Huntsman, C. Blake Gilks, Stephen Yip, Ali Bashashati
+  year: 2020
+  preprint: 0
+  url: https://onlinelibrary.wiley.com/doi/abs/10.1002/path.5509
+  display: "The Journal of Pathology"
+
+- title: "TMEM30A loss-of-function mutations drive lymphomagenesis and confer therapeutically exploitable vulnerability in B-cell lymphoma"
+  authors: Daisuke Ennishi, Shannon Healy, Ali Bashashati, Saeed Saberi, Christoffer Hother, Anja Mottok, Fong Chun Chan, Lauren Chong, Libin Abraham, Robert Kridel, Merrill Boyle, Barbara Meissner, Tomohiro Aoki, Katsuyoshi Takata, Bruce W Woolcock, Elena Viganò, Michael Gold, Laurie L Molday, Robert S Molday, Adele Telenius, Michael Y Li, Nicole Wretham, Nancy Dos Santos, Mark Wong, Natasja N Viller, Robert A Uger, Gerben Duns, Abigail Baticados, Angel Madero, Brianna N Bristow, Pedro Farinha, Graham W Slack, Susana Ben-Neriah, Daniel Lai, Allen W Zhang, Sohrab Salehi, Hennady P Shulha, Derek S Chiu, Sara Mostafavi, Alina S Gerrie, Christopher Rushton, Diego Villa, Laurie H Sehn, Kerry J Savage, Andrew J Mungall, Andrew P Weng, Marcel B Bally, Ryan D Morin, Gabriela V Cohen Freue, Louis M Staudt, Joseph M Connors, Marco A Marra, Sohrab P Shah, Randy D Gascoyne, David W Scott, Christian Steidl
+  url: https://www.nature.com/articles/s41591-020-0757-z
+
+- title: "Generation of Synthetic Ovarian Carcinoma Microscopic Images for Proficiency Testing"
+  authors: Adrian Levine, Chien Chen Peng, David Farnell, Basile Tessier-Cloutier, Mitchell Nursey, Davood Karimi, Steven Jones, Septimiu Salcudean, David Huntsman, Stephen Yip, C Blake Gilks, Ali Bashashati
+  url: 
+
+- title: "Endometrial Cancer Molecular Risk Stratification is Equally Prognostic for Endometrioid Ovarian Carcinoma"
+  authors: Pauline Krämer, Aline Talhouk, Mary Anne Brett, Derek S Chiu, Evan S Cairns, Daniëlla A Scheunhage, Rory Fl Hammond, David Farnell, Tayyebeh Mehrane Nazeran, Marcel Grube, Zhouchunyang Xia, Janine Senz, Samuel Leung, Lukas Feil, Jana Pasternak, Katherine Dixon, Andreas Hartkopf, Bernhard Krämer, Sara Brucker, Florian Heitz, Andreas du Bois, Philipp Harter, Felix Kommoss, Hans-Peter Sinn, Sabine Heublein, Friedrich Kommoss, Hans-Walter Vollert, Ranjit Manchanda, Cornelis D de Kroon, Hans W Nijman, Marco de Bruyn, Emily F Thompson, Ali Bashashati, Jessica N McAlpine, Naveena Singh, Anna V Tinker, Annette Staebler, Tjalling Bosse, Stefan Kommoss, Martin Köbel, Michael S Anglesio
+  url: https://clincancerres.aacrjournals.org/content/early/2020/09/04/1078-0432.CCR-20-1268.abstract

--- a/_pages/alib.md
+++ b/_pages/alib.md
@@ -46,6 +46,40 @@ team_member_name: Ali Bashashati
 <br/>
 {{member.desc}}
 {% endif %}
+
+<div class="col-lg-12">
+{% assign firstname = member.name | split: ' ' | first %}
+{% assign lastname = member.name | split: ' ' | last %}
+{% for paper in site.data.publication_list %}
+    {% assign authors = paper.authors | split: ',' %}
+    {% for author in authors %}
+        {% if author contains firstname %}
+            {% if author contains lastname %}
+                {% assign has_papers = true %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+{% if has_papers == true %}
+<h4>Papers</h4>
+{% for paper in site.data.publication_list %}
+    {% assign authors = paper.authors | split: ',' %}
+    {% for author in authors %}
+        {% if author contains firstname %}
+            {% if author contains lastname %}
+                {% if paper.url == nil %}
+                <p>{{ paper.title }}</p>
+                {% else %}
+                <p><a href="{{ paper.url }}" class="off">{{ paper.title }}</a></p>
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+{% endif %}
+</div>
+
 {% endif %}
 
 {% endfor %}

--- a/_pages/mnursey.md
+++ b/_pages/mnursey.md
@@ -46,6 +46,40 @@ team_member_name: Mitchell Nursey
 <br/>
 {{member.desc}}
 {% endif %}
+
+<div class="col-lg-12">
+{% assign firstname = member.name | split: ' ' | first %}
+{% assign lastname = member.name | split: ' ' | last %}
+{% for paper in site.data.publication_list %}
+    {% assign authors = paper.authors | split: ',' %}
+    {% for author in authors %}
+        {% if author contains firstname %}
+            {% if author contains lastname %}
+                {% assign has_papers = true %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+{% if has_papers == true %}
+<h4>Papers</h4>
+{% for paper in site.data.publication_list %}
+    {% assign authors = paper.authors | split: ',' %}
+    {% for author in authors %}
+        {% if author contains firstname %}
+            {% if author contains lastname %}
+                {% if paper.url == nil %}
+                <p>{{ paper.title }}</p>
+                {% else %}
+                <p><a href="{{ paper.url }}" class="off">{{ paper.title }}</a></p>
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+{% endif %}
+</div>
+
 {% endif %}
 
 {% endfor %}

--- a/_pages/ywang.md
+++ b/_pages/ywang.md
@@ -46,6 +46,40 @@ team_member_name: Yiping Wang
 <br/>
 {{member.desc}}
 {% endif %}
+
+<div class="col-lg-12">
+{% assign firstname = member.name | split: ' ' | first %}
+{% assign lastname = member.name | split: ' ' | last %}
+{% for paper in site.data.publication_list %}
+    {% assign authors = paper.authors | split: ',' %}
+    {% for author in authors %}
+        {% if author contains firstname %}
+            {% if author contains lastname %}
+                {% assign has_papers = true %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+{% if has_papers == true %}
+<h4>Papers</h4>
+{% for paper in site.data.publication_list %}
+    {% assign authors = paper.authors | split: ',' %}
+    {% for author in authors %}
+        {% if author contains firstname %}
+            {% if author contains lastname %}
+                {% if paper.url == nil %}
+                <p>{{ paper.title }}</p>
+                {% else %}
+                <p><a href="{{ paper.url }}" class="off">{{ paper.title }}</a></p>
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+{% endif %}
+</div>
+
 {% endif %}
 
 {% endfor %}

--- a/_pages/yxia.md
+++ b/_pages/yxia.md
@@ -46,6 +46,40 @@ team_member_name: Yang Xia
 <br/>
 {{member.desc}}
 {% endif %}
+
+<div class="col-lg-12">
+{% assign firstname = member.name | split: ' ' | first %}
+{% assign lastname = member.name | split: ' ' | last %}
+{% for paper in site.data.publication_list %}
+    {% assign authors = paper.authors | split: ',' %}
+    {% for author in authors %}
+        {% if author contains firstname %}
+            {% if author contains lastname %}
+                {% assign has_papers = true %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+{% if has_papers == true %}
+<h4>Papers</h4>
+{% for paper in site.data.publication_list %}
+    {% assign authors = paper.authors | split: ',' %}
+    {% for author in authors %}
+        {% if author contains firstname %}
+            {% if author contains lastname %}
+                {% if paper.url == nil %}
+                <p>{{ paper.title }}</p>
+                {% else %}
+                <p><a href="{{ paper.url }}" class="off">{{ paper.title }}</a></p>
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+{% endif %}
+</div>
+
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
For team members with description pages, this code adds a section containing their papers. Any paper listed in _data/publication_list.yml that the member authored will appear in this section. Papers can be added to the publication list manually or copy and pasted from the output of scripts/bibtex_to_yaml.py (if a BibTex file is more convenient).